### PR TITLE
make hue-light compliant with JCasC

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,2 @@
+// Build the plugin using https://github.com/jenkins-infra/pipeline-library
+buildPlugin(jenkinsVersions: [null, "2.107.1"])

--- a/pom.xml
+++ b/pom.xml
@@ -58,13 +58,6 @@
         </pluginRepository>
     </pluginRepositories>
 
-    <distributionManagement>
-        <repository>
-            <id>maven.jenkins-ci.org</id>
-            <url>http://maven.jenkins-ci.org:8081/content/repositories/releases/</url>
-        </repository>
-    </distributionManagement>
-
     <properties>
         <!--
           explicitly specifying the latest version here because one we get from the parent POM

--- a/pom.xml
+++ b/pom.xml
@@ -3,11 +3,10 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>1.509.2</version>
-        <!-- which version of Jenkins is this plugin built against? -->
+        <version>3.14</version>
+        <relativePath></relativePath>
     </parent>
 
-    <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>hue-light</artifactId>
     <version>1.2.1-SNAPSHOT</version>
     <packaging>hpi</packaging>
@@ -44,7 +43,7 @@
     <repositories>
         <repository>
             <id>repo.jenkins-ci.org</id>
-            <url>http://repo.jenkins-ci.org/public/</url>
+            <url>https://repo.jenkins-ci.org/public/</url>
         </repository>
         <repository>
             <id>libs</id>
@@ -55,7 +54,7 @@
     <pluginRepositories>
         <pluginRepository>
             <id>repo.jenkins-ci.org</id>
-            <url>http://repo.jenkins-ci.org/public/</url>
+            <url>https://repo.jenkins-ci.org/public/</url>
         </pluginRepository>
     </pluginRepositories>
 
@@ -71,7 +70,8 @@
           explicitly specifying the latest version here because one we get from the parent POM
           tends to lag behind a bit
         -->
-        <maven-hpi-plugin.version>1.96</maven-hpi-plugin.version>
+        <jenkins.version>1.651.3</jenkins.version>
+        <java.level>7</java.level>
     </properties>
 
     <dependencies>

--- a/src/main/java/org/jenkinsci/plugins/hue_light/LightNotifier.java
+++ b/src/main/java/org/jenkinsci/plugins/hue_light/LightNotifier.java
@@ -23,15 +23,16 @@ import nl.q42.jue.Light;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.DataBoundSetter;
 
 
 public class LightNotifier extends Notifier {
     private static final String FORM_KEY_BRIDGE_IP = "bridgeIp";
     private static final String FORM_KEY_BRIDGE_USERNAME = "bridgeUsername";
-    private static final String FORM_KEY_BLUE = "colorBlue";
-    private static final String FORM_KEY_GREEN = "colorGreen";
-    private static final String FORM_KEY_YELLOW = "colorYellow";
-    private static final String FORM_KEY_RED = "colorRed";
+    private static final String FORM_KEY_BLUE = "blue";
+    private static final String FORM_KEY_GREEN = "green";
+    private static final String FORM_KEY_YELLOW = "yellow";
+    private static final String FORM_KEY_RED = "red";
     private static final String FORM_KEY_SATURATION = "saturation";
     private static final String FORM_KEY_BRIGHTNESS = "brightness";
     private final HashSet<String> lightId;
@@ -394,22 +395,10 @@ public class LightNotifier extends Notifier {
         }
 
         @Override
-        public boolean configure(StaplerRequest req, JSONObject formData) throws FormException {
-            if (!formData.containsKey(FORM_KEY_BRIDGE_IP) || !formData.containsKey(FORM_KEY_BRIDGE_USERNAME))
-                return false; // keep client on config page
-
-            this.bridgeIp = formData.getString(FORM_KEY_BRIDGE_IP);
-            this.bridgeUsername = formData.getString(FORM_KEY_BRIDGE_USERNAME);
-            this.blue = formData.getString(FORM_KEY_BLUE);
-            this.green = formData.getString(FORM_KEY_GREEN);
-            this.yellow = formData.getString(FORM_KEY_YELLOW);
-            this.red = formData.getString(FORM_KEY_RED);
-            this.saturation = formData.getString(FORM_KEY_SATURATION);
-            this.brightness = formData.getString(FORM_KEY_BRIGHTNESS);
-
-            this.save();
-
-            return super.configure(req, formData);
+        public boolean configure(StaplerRequest req, JSONObject json) throws FormException {
+            req.bindJSON(this, json);
+            save();
+            return true;
         }
 
         public String getBridgeIp() {
@@ -442,6 +431,46 @@ public class LightNotifier extends Notifier {
 
         public String getBrightness() {
             return this.brightness;
+        }
+
+        @DataBoundSetter
+        public void setBridgeIp(String bridgeIp) {
+            this.bridgeIp = bridgeIp;
+        }
+
+        @DataBoundSetter
+        public void setBridgeUsername(String bridgeUsername) {
+            this.bridgeUsername = bridgeUsername;
+        }
+
+        @DataBoundSetter
+        public void setBlue(String blue) {
+            this.blue = blue;
+        }
+
+        @DataBoundSetter
+        public void setGreen(String green) {
+            this.green = green;
+        }
+
+        @DataBoundSetter
+        public void setYellow(String yellow) {
+            this.yellow = yellow;
+        }
+
+        @DataBoundSetter
+        public void setRed(String red) {
+            this.red = red;
+        }
+
+        @DataBoundSetter
+        public void setSaturation(String saturation) {
+            this.saturation = saturation;
+        }
+
+        @DataBoundSetter
+        public void setBrightness(String brightness) {
+            this.brightness = brightness;
         }
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/hue_light/LightNotifier.java
+++ b/src/main/java/org/jenkinsci/plugins/hue_light/LightNotifier.java
@@ -27,14 +27,6 @@ import org.kohsuke.stapler.DataBoundSetter;
 
 
 public class LightNotifier extends Notifier {
-    private static final String FORM_KEY_BRIDGE_IP = "bridgeIp";
-    private static final String FORM_KEY_BRIDGE_USERNAME = "bridgeUsername";
-    private static final String FORM_KEY_BLUE = "blue";
-    private static final String FORM_KEY_GREEN = "green";
-    private static final String FORM_KEY_YELLOW = "yellow";
-    private static final String FORM_KEY_RED = "red";
-    private static final String FORM_KEY_SATURATION = "saturation";
-    private static final String FORM_KEY_BRIGHTNESS = "brightness";
     private final HashSet<String> lightId;
     private final String preBuild;
     private final String goodBuild;

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <div>
   Control the <a href="http://meethue.com" target="_blank">Philips hue lights</a> depending on the build state.
   <div style="color: red;">If you are using an older version, you must re-save the global and jobs configuration.</div>

--- a/src/main/resources/org/jenkinsci/plugins/hue_light/LightNotifier/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/hue_light/LightNotifier/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <f:entry title="ID of a light" field="lightId">
     <f:textbox />

--- a/src/main/resources/org/jenkinsci/plugins/hue_light/LightNotifier/global.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/hue_light/LightNotifier/global.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <f:section title="Hue-Light">
     <f:entry title="IP of the bridge" field="bridgeIp">
@@ -6,16 +7,16 @@
     <f:entry title="Username" field="bridgeUsername">
       <f:textbox />
     </f:entry>
-    <f:entry title="Red" field="colorRed">
+    <f:entry title="Red" field="red">
       <f:textbox default="0" />
     </f:entry>
-    <f:entry title="Yellow" field="colorYellow">
+    <f:entry title="Yellow" field="yellow">
       <f:textbox default="12750" />
     </f:entry>
-    <f:entry title="Green" field="colorGreen">
+    <f:entry title="Green" field="green">
       <f:textbox default="25717" />
     </f:entry>
-    <f:entry title="Blue" field="colorBlue">
+    <f:entry title="Blue" field="blue">
       <f:textbox default="46920" />
     </f:entry>
     <f:entry title="Saturation" field="saturation">


### PR DESCRIPTION
Changes introduces in this PR makes hue-light-plugin compliant with https://github.com/jenkinsci/configuration-as-code-plugin

had to bump jenkins version to make it possible to use DataBoundSetter

cc @ndeloof 